### PR TITLE
Melhorias NMAR

### DIFF
--- a/eraser.py
+++ b/eraser.py
@@ -1,8 +1,7 @@
-from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter, ArgumentTypeError
+from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 import pandas as pd
-import importlib
-from typing import Union
-from Strategy.MissingDataStrategy import IMissingDataStrategy, MCAR, NMAR, MAR
+from Strategy.MissingDataStrategy import IMissingDataStrategy
+from utils import missing_rate_float, str_to_class
 
 MISSING_DATA_STRATEGY_MODULE = "Strategy.MissingDataStrategy"
 
@@ -13,8 +12,9 @@ class Eraser:
         input_file: str, 
         output_file: str, 
         attribute: str, 
-        mechanism: str == "MCAR",
-        missing_rate: float == 0.3, 
+        mechanism: str = "MCAR",
+        missing_rate: float = 0.3,
+        query: str = "", 
     ) -> None: 
         """
         Reads data from a csv 'input_file' and erase values from 'attribute' column using a missing data 'mechanism' at a 'missing_rate'
@@ -22,7 +22,7 @@ class Eraser:
         """
         self.strategy = str_to_class(MISSING_DATA_STRATEGY_MODULE, mechanism)
         data = pd.read_csv(input_file)
-        data[attribute] = self.strategy.execute(data[attribute], missing_rate)
+        data[attribute] = self.strategy.execute(data[attribute], missing_rate, query)
         data.to_csv(self.handle_output_file_name(output_file), index=False)
         print(f"File '{self.handle_output_file_name(output_file)}' successfully generated")
     
@@ -35,35 +35,6 @@ class Eraser:
         else:
             return f"{output_file}.csv"
 
-
-def missing_rate_float(x: float) -> float:
-    """
-    Custom type function for validating the "missing_range" argument
-    """
-    try:
-        x = float(x)
-    except ValueError:
-        raise ArgumentTypeError("%r not a floating-point literal" % (x,))
-
-    if x < 0.0 or x > 1.0:
-        raise ArgumentTypeError("%r not in range [0.0, 1.0]"%(x,))
-    return x
-
-
-def str_to_class(module_name: str, class_name: str) -> Union[IMissingDataStrategy, None]:
-    """
-    Return a class instance from a string reference
-    """
-    try:
-        module_ = importlib.import_module(module_name)
-        try:
-            class_ = getattr(module_, class_name)()
-        except AttributeError:
-            print('Class does not exist')
-    except ImportError:
-        print('Module does not exist')
-    return class_ or None
-
 def main():
     """
     Main function
@@ -75,6 +46,7 @@ def main():
     parser.add_argument("-a", "--attribute", help="Name of the attribute to erase values")
     parser.add_argument("-m", "--mechanism", default="MCAR", choices=("MCAR", "MAR", "NMAR"), help="Missing data mechanism to be applied")
     parser.add_argument("-r", "--missing_rate", type=missing_rate_float, default=0.3, help="The rate in which the attribute values will be erased")
+    parser.add_argument("-q", "--query", default="", help="The query to apply NMAR mechanism. A string as in the example 'x > 3 & x < 5 | x == 7', where x represents values in the chosen column. Valid tokens: x, ==, >, >=, <, <=, &, |, (, )")
     args = vars(parser.parse_args())
 
     input_file = args["input_file"]
@@ -82,9 +54,10 @@ def main():
     attribute = args["attribute"]
     mechanism = args["mechanism"]
     missing_rate = args["missing_rate"]
+    query = args["query"]
 
     eraser = Eraser()
-    eraser.eraser(input_file, output_file, attribute, mechanism, missing_rate)
+    eraser.eraser(input_file, output_file, attribute, mechanism, missing_rate, query)
 
 if __name__ == '__main__': 
     main()

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,7 @@
+import importlib
 from typing import Optional, Union
 import logging
+from argparse import ArgumentTypeError
 
 
 class Logging:
@@ -18,3 +20,32 @@ class Csv:
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.file.close()
+        
+
+def missing_rate_float(x: float) -> float:
+    """
+    Custom type function for validating "missing_range" argument in eraser module
+    """
+    try:
+        x = float(x)
+    except ValueError:
+        raise ArgumentTypeError("%r not a floating-point literal" % (x,))
+
+    if x < 0.0 or x > 1.0:
+        raise ArgumentTypeError("%r not in range [0.0, 1.0]"%(x,))
+    return x
+
+
+def str_to_class(module_name: str, class_name: str):
+    """
+    Return a class instance from a string reference
+    """
+    try:
+        module_ = importlib.import_module(module_name)
+        try:
+            class_ = getattr(module_, class_name)()
+        except AttributeError:
+            print('Class does not exist')
+    except ImportError:
+        print('Module does not exist')
+    return class_ or None


### PR DESCRIPTION
- Adiciona parâmetro argumento "--query" no script de linha de comando do eraser.py, representando uma query para filtrar valores de uma coluna. 
  Exemplo de uso: `python eraser.py -i iris.csv -o iris_missing.csv -m NMAR -a "sepal.length" -r .7 -q "x >= 1 | x<=6"`
  Tokens aceitos para a query: ==, >, >=, <, <=, &, |, (, ). Com isso, é possível aceitar múltiplas condições.